### PR TITLE
Fix pickling error by disabling custom commands in hooks

### DIFF
--- a/imperium_pim/hooks.py
+++ b/imperium_pim/hooks.py
@@ -281,5 +281,5 @@ after_migrate = "imperium_pim.utils.sync_desktop_icons"
 # Custom bench commands
 # ---------------------
 # Register custom bench commands for this app
-from imperium_pim.commands import commands
-
+# Note: Commands temporarily disabled due to pickling issues
+# from imperium_pim.commands import commands


### PR DESCRIPTION
The build_frontend command was causing a PicklingError during app installation because function objects cannot be serialized by Frappe's caching system. Temporarily disabled the command import to allow successful installation.

The frontend can still be built manually using the build.sh script.