### PR TITLE
Fix: Correct Frappe asset reference in pim.html

### DIFF
--- a/imperium_pim/www/pim.html
+++ b/imperium_pim/www/pim.html
@@ -7,7 +7,7 @@
     <meta name="description" content="{{ description }}">
     
     <!-- Include Frappe's core JavaScript first -->
-    <script src="/assets/frappe/js/frappe-web.min.js"></script>
+    <script src="/assets/frappe/js/frappe-web.bundle.js"></script>
     
     <!-- Include React build CSS -->
     <link rel="stylesheet" href="/assets/imperium_pim/_next/static/css/81d3752c4dbd3838.css">


### PR DESCRIPTION
- Change /assets/frappe/js/frappe-web.min.js to /assets/frappe/js/frappe-web.bundle.js
- Resolves 404 error when loading Frappe framework
- Ensures proper Frappe JS framework availability for React app