### PR TITLE
Fix: Add type="module" to Frappe script tag in pim.html

### DIFF
--- a/imperium_pim/www/pim.html
+++ b/imperium_pim/www/pim.html
@@ -7,7 +7,7 @@
     <meta name="description" content="{{ description }}">
     
     <!-- Include Frappe's core JavaScript first -->
-    <script src="/assets/frappe/js/frappe-web.bundle.js"></script>
+    <script type="module" src="/assets/frappe/js/frappe-web.bundle.js"></script>
     
     <!-- Include React build CSS -->
     <link rel="stylesheet" href="/assets/imperium_pim/_next/static/css/81d3752c4dbd3838.css">


### PR DESCRIPTION
- Add type="module" attribute to frappe-web.bundle.js script tag
- Resolves ES6 import syntax errors in Frappe JavaScript bundle
- Allows proper loading of ES6 modules with import statements
- Ensures Frappe framework loads correctly without syntax errors