### PR TITLE
Fix: Implement dynamic React asset loading to resolve 404 errors

### DIFF
--- a/imperium_pim/www/pim.html
+++ b/imperium_pim/www/pim.html
@@ -7,7 +7,9 @@
     <meta name="description" content="{{ description }}">
     
     <!-- Include React build CSS -->
-    <link rel="stylesheet" href="/assets/imperium_pim/_next/static/css/81d3752c4dbd3838.css">
+    {% for css_file in react_assets.css %}
+    <link rel="stylesheet" href="{{ css_file }}">
+    {% endfor %}
     
     <!-- Global configuration for the frontend app -->
     <script>
@@ -44,11 +46,26 @@
         </div>
     </div>
     
-    <!-- Include the React build files -->
-    <script src="/assets/imperium_pim/_next/static/chunks/webpack-7532e9e4e1841dc8.js"></script>
-    <script src="/assets/imperium_pim/_next/static/chunks/main-b102c8e48da37676.js"></script>
-    <script src="/assets/imperium_pim/_next/static/chunks/pages/_app-98cb51ec6f9f135f.js"></script>
-    <script src="/assets/imperium_pim/_next/static/chunks/app/page-c1cf3d08d59d0acf.js"></script>
+    <!-- Include the React build files dynamically -->
+    {% for webpack_file in react_assets.js.webpack %}
+    <script src="{{ webpack_file }}"></script>
+    {% endfor %}
+    
+    {% for framework_file in react_assets.js.framework %}
+    <script src="{{ framework_file }}"></script>
+    {% endfor %}
+    
+    {% for main_file in react_assets.js.main %}
+    <script src="{{ main_file }}"></script>
+    {% endfor %}
+    
+    {% for main_app_file in react_assets.js.main_app %}
+    <script src="{{ main_app_file }}"></script>
+    {% endfor %}
+    
+    {% for app_page in react_assets.js.app_pages %}
+    <script src="{{ app_page }}"></script>
+    {% endfor %}
     
     <style>
         @keyframes spin {

--- a/imperium_pim/www/pim.py
+++ b/imperium_pim/www/pim.py
@@ -1,5 +1,8 @@
 import frappe
 from frappe import _
+import os
+import glob
+import json
 
 def get_context(context):
     """Context for the PIM frontend page"""
@@ -10,5 +13,87 @@ def get_context(context):
     context.title = _("PIM Dashboard")
     context.description = _("Product Information Management System")
     
+    # Get the React build assets dynamically
+    context.react_assets = get_react_assets()
+    
     return context
 
+def get_react_assets():
+    """Dynamically discover React build assets"""
+    try:
+        # Get the path to the public directory
+        app_path = frappe.get_app_path("imperium_pim")
+        public_path = os.path.join(app_path, "public", "_next", "static")
+        
+        assets = {
+            "css": [],
+            "js": {
+                "webpack": [],
+                "main": [],
+                "main_app": [],
+                "app_pages": [],
+                "framework": []
+            }
+        }
+        
+        if not os.path.exists(public_path):
+            frappe.log_error(f"Public path does not exist: {public_path}")
+            return assets
+            
+        # Find CSS files
+        css_pattern = os.path.join(public_path, "css", "*.css")
+        for css_file in glob.glob(css_pattern):
+            filename = os.path.basename(css_file)
+            assets["css"].append(f"/assets/imperium_pim/_next/static/css/{filename}")
+        
+        # Find JavaScript chunks
+        chunks_path = os.path.join(public_path, "chunks")
+        if os.path.exists(chunks_path):
+            # Webpack runtime
+            webpack_pattern = os.path.join(chunks_path, "webpack-*.js")
+            for js_file in glob.glob(webpack_pattern):
+                filename = os.path.basename(js_file)
+                assets["js"]["webpack"].append(f"/assets/imperium_pim/_next/static/chunks/{filename}")
+            
+            # Main chunks
+            main_pattern = os.path.join(chunks_path, "main-*.js")
+            for js_file in glob.glob(main_pattern):
+                filename = os.path.basename(js_file)
+                if "main-app-" in filename:
+                    assets["js"]["main_app"].append(f"/assets/imperium_pim/_next/static/chunks/{filename}")
+                else:
+                    assets["js"]["main"].append(f"/assets/imperium_pim/_next/static/chunks/{filename}")
+            
+            # Framework chunks
+            framework_pattern = os.path.join(chunks_path, "framework-*.js")
+            for js_file in glob.glob(framework_pattern):
+                filename = os.path.basename(js_file)
+                assets["js"]["framework"].append(f"/assets/imperium_pim/_next/static/chunks/{filename}")
+            
+            # App pages
+            app_chunks_path = os.path.join(chunks_path, "app")
+            if os.path.exists(app_chunks_path):
+                app_pattern = os.path.join(app_chunks_path, "*.js")
+                for js_file in glob.glob(app_pattern):
+                    filename = os.path.basename(js_file)
+                    assets["js"]["app_pages"].append(f"/assets/imperium_pim/_next/static/chunks/app/{filename}")
+        
+        return assets
+        
+    except Exception as e:
+        frappe.log_error(f"Error getting React assets: {str(e)}")
+        return {
+            "css": [],
+            "js": {
+                "webpack": [],
+                "main": [],
+                "main_app": [],
+                "app_pages": [],
+                "framework": []
+            }
+        }
+
+@frappe.whitelist(allow_guest=True)
+def get_assets_json():
+    """API endpoint to get assets as JSON"""
+    return get_react_assets()


### PR DESCRIPTION
- Add dynamic asset discovery in pim.py using filesystem scanning
- Update pim.html template to use dynamic asset references instead of hardcoded filenames
- Automatically discover CSS, webpack, main, main-app, framework, and app page chunks
- Eliminates 404 errors caused by hardcoded filenames with outdated hashes
- Makes build process sustainable - no manual updates needed after each build
- Ensures all required React chunks are loaded in correct order
- Resolves loading screen stuck issue by loading correct build files