### PR TITLE
Fix: Correct __NEXT_DATA__ page configuration for /pim route

### DIFF
--- a/imperium_pim/www/pim.html
+++ b/imperium_pim/www/pim.html
@@ -17,7 +17,7 @@
         "props": {
             "pageProps": {}
         },
-        "page": "/",
+        "page": "/pim",
         "query": {},
         "buildId": "development",
         "assetPrefix": "/assets/imperium_pim",


### PR DESCRIPTION
- Change 'page': '/' to 'page': '/pim' in __NEXT_DATA__ script
- This tells Next.js runtime to load the /pim page component instead of root
- Resolves component mounting issue where Next.js was looking for wrong route
- PIMDashboard component should now mount correctly at /pim URL

The Next.js runtime uses the 'page' field to determine which component to render. Previously it was set to '/' (root) but the actual URL is /pim, causing a mismatch.