### PR TITLE
Fix: Switch to pure client-side rendering to avoid hydration mismatches

### DIFF
--- a/imperium_pim/www/pim.html
+++ b/imperium_pim/www/pim.html
@@ -38,7 +38,7 @@
 {% endblock %}
 
 {% block content %}
-    <!-- React app will mount here - Next.js App Router will hydrate this -->
+    <!-- React app will render here client-side (no hydration, pure CSR) -->
     <div id="__next">
         <div style="display: flex; align-items: center; justify-content: center; min-height: 100vh;">
             <div style="text-align: center;">
@@ -47,13 +47,6 @@
             </div>
         </div>
     </div>
-    
-    <!-- Initialize Next.js hydration -->
-    <script>
-        // Initialize Next.js hydration system
-        (self.__next_f = self.__next_f || []).push([0]);
-        self.__next_f.push([2, null]);
-    </script>
     
     <!-- Include the React build files dynamically -->
     {% for webpack_file in react_assets.js.webpack %}


### PR DESCRIPTION
- Remove manual hydration bootstrap scripts that were causing conflicts
- Keep simple loading placeholder in #__next div
- Let React render everything client-side from scratch (CSR)
- This avoids DOM structure mismatches between server and client

The issue was trying to hydrate a complex dashboard into a simple loading div. Pure CSR is simpler and more reliable - React will replace the loading placeholder with the full dashboard once it mounts and renders.