### PR TITLE
Fix get_site_config import error in utils.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,8 @@ The frontend runs on `http://localhost:3000` and connects to your local Frappe b
 # Check backend CORS configuration
 cd backend
 bench --site your-site console
->>> from frappe.utils import get_site_config
->>> print(get_site_config())
+>>> import frappe
+>>> print(frappe.get_site_config())
 
 # Test API connectivity
 curl -v https://your-backend-domain.com/api/method/imperium_pim.api.ping
@@ -263,4 +263,3 @@ If you encounter issues:
 ---
 
 **🎉 You're all set!** Your PIM system now runs with modern separate deployment architecture - frontend on Vercel's global CDN and backend on your Frappe site.
-

--- a/backend/imperium_pim/utils.py
+++ b/backend/imperium_pim/utils.py
@@ -36,7 +36,6 @@ If the module still doesn't appear:
 """
 
 import frappe
-from frappe.utils import get_site_config
 import json
 
 
@@ -75,7 +74,7 @@ def handle_cors_preflight():
     """
     if frappe.request.method == "OPTIONS":
         # Get site configuration
-        site_config = get_site_config()
+        site_config = frappe.get_site_config()
         
         # Get origin from request
         origin = frappe.get_request_header("Origin")
@@ -107,7 +106,7 @@ def add_cors_headers():
     This function is called after each request via hooks.py
     """
     # Get site configuration
-    site_config = get_site_config()
+    site_config = frappe.get_site_config()
     
     # Get origin from request
     origin = frappe.get_request_header("Origin")
@@ -149,7 +148,7 @@ def setup_cors_for_site(frontend_urls=None):
             "https://your-frontend-domain.com",  # Production
         ]
     
-    site_config = get_site_config()
+    site_config = frappe.get_site_config()
     
     # Update CORS settings
     cors_settings = {


### PR DESCRIPTION
- Replace incorrect import from frappe.utils with frappe.get_site_config()
- Update all function calls to use frappe.get_site_config() instead
- Fix documentation in README.md to show correct import
- This resolves the PicklingError during Frappe app installation