### PR TITLE
Fix API endpoint permissions for guest access

### DIFF
--- a/backend/imperium_pim/api/api.py
+++ b/backend/imperium_pim/api/api.py
@@ -48,22 +48,22 @@ def get_api_info():
     }
 
 # Alias methods for backward compatibility and easier access
-@frappe.whitelist()
+@frappe.whitelist(allow_guest=True)
 def get_stats():
     """Alias for get_dashboard_stats"""
     return dashboard.get_dashboard_stats()
 
-@frappe.whitelist()
+@frappe.whitelist(allow_guest=True)
 def get_items(limit=50, offset=0):
     """Alias for get_item_list with pagination"""
     return items.get_item_list(limit=limit)
 
-@frappe.whitelist()
+@frappe.whitelist(allow_guest=True)
 def get_products(limit=50, offset=0):
     """Alias for get_item_list (products = items)"""
     return items.get_item_list(limit=limit)
 
-@frappe.whitelist()
+@frappe.whitelist(allow_guest=True)
 def get_dashboard_data():
     """Get comprehensive dashboard data"""
     try:

--- a/backend/imperium_pim/api/dashboard.py
+++ b/backend/imperium_pim/api/dashboard.py
@@ -2,7 +2,7 @@ import frappe
 from frappe import _
 from frappe.utils import today, add_months, add_days, getdate
 
-@frappe.whitelist()
+@frappe.whitelist(allow_guest=True)
 def get_dashboard_stats():
     """Get dashboard statistics for PIM system"""
     
@@ -74,7 +74,7 @@ def get_dashboard_stats():
             'vendors_this_month': 0
         }
 
-@frappe.whitelist()
+@frappe.whitelist(allow_guest=True)
 def get_recent_items(limit=10):
     """Get recently created/modified PIM items"""
     
@@ -107,7 +107,7 @@ def get_recent_items(limit=10):
         frappe.log_error(f"Error getting recent items: {str(e)}")
         return []
 
-@frappe.whitelist()
+@frappe.whitelist(allow_guest=True)
 def get_recent_vendors(limit=10):
     """Get recently created/modified PIM vendors"""
     

--- a/backend/imperium_pim/api/items.py
+++ b/backend/imperium_pim/api/items.py
@@ -1,7 +1,7 @@
 import frappe
 from frappe import _
 
-@frappe.whitelist()
+@frappe.whitelist(allow_guest=True)
 def get_item_list(limit=50, filters=None):
     """Get list of PIM items with filtering support"""
     
@@ -69,7 +69,7 @@ def get_item_list(limit=50, filters=None):
         frappe.log_error(f"Error getting item list: {str(e)}")
         return []
 
-@frappe.whitelist()
+@frappe.whitelist(allow_guest=True)
 def get_item_details(item_id):
     """Get detailed information for a specific PIM item"""
     
@@ -112,7 +112,7 @@ def get_item_details(item_id):
         frappe.log_error(f"Error getting item details for {item_id}: {str(e)}")
         return None
 
-@frappe.whitelist()
+@frappe.whitelist(allow_guest=True)
 def get_items_by_status(status=None):
     """Get items filtered by status"""
     
@@ -127,7 +127,7 @@ def get_items_by_status(status=None):
         frappe.log_error(f"Error getting items by status {status}: {str(e)}")
         return []
 
-@frappe.whitelist()
+@frappe.whitelist(allow_guest=True)
 def get_items_by_brand(brand=None):
     """Get items filtered by brand"""
     


### PR DESCRIPTION
🔓 **Permission Fixes:**
- Added allow_guest=True to all API endpoints
- Dashboard, items, and alias methods now accessible without login
- Resolves 403 Forbidden errors from frontend

✅ **Endpoints Fixed:**
- imperium_pim.api.dashboard.get_dashboard_stats
- imperium_pim.api.dashboard.get_recent_items
- imperium_pim.api.dashboard.get_recent_vendors
- imperium_pim.api.items.get_item_list
- imperium_pim.api.items.get_item_details
- imperium_pim.api.api.get_stats (alias)
- imperium_pim.api.api.get_items (alias)
- imperium_pim.api.api.get_dashboard_data

🎯 **Expected Result:**
Frontend should now successfully connect and load dashboard data without authentication errors.