### PR TITLE
Improve Redis connection testing and debugging

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y \
     tree \
     iputils-ping \
     procps \
+    redis-tools \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Python development tools

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -13,6 +13,7 @@ USER root
 RUN apt-get update && apt-get install -y \
     curl \
     wget \
+    redis-tools \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 
@@ -40,4 +41,3 @@ HEALTHCHECK --interval=60s --timeout=30s --start-period=120s --retries=5 \
 
 # Set the startup command
 CMD ["/home/frappe/start-prod.sh"]
-

--- a/backend/start-prod.sh
+++ b/backend/start-prod.sh
@@ -78,22 +78,37 @@ fi
 
 # Wait for Redis to be ready
 echo "⏳ Waiting for Redis to be ready..."
-attempt=1
 
-while [ $attempt -le $max_attempts ]; do
-    if redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" ${REDIS_PASSWORD:+-a "$REDIS_PASSWORD"} ping > /dev/null 2>&1; then
-        echo "✅ Redis is ready!"
-        break
-    else
-        echo "🔄 Attempt $attempt/$max_attempts: Redis not ready, waiting 5 seconds..."
-        sleep 5
-        attempt=$((attempt + 1))
+# Check if redis-cli is available
+if ! command -v redis-cli > /dev/null 2>&1; then
+    echo "⚠️  redis-cli not found, skipping Redis connectivity test"
+    echo "✅ Assuming Redis is ready (will be tested during Frappe startup)"
+else
+    attempt=1
+    
+    while [ $attempt -le $max_attempts ]; do
+        # Test Redis connection with detailed error output
+        if [ ! -z "$REDIS_PASSWORD" ]; then
+            redis_test_output=$(redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" -a "$REDIS_PASSWORD" ping 2>&1)
+        else
+            redis_test_output=$(redis-cli -h "$REDIS_HOST" -p "$REDIS_PORT" ping 2>&1)
+        fi
+        
+        if echo "$redis_test_output" | grep -q "PONG"; then
+            echo "✅ Redis is ready!"
+            break
+        else
+            echo "🔄 Attempt $attempt/$max_attempts: Redis not ready, waiting 5 seconds..."
+            echo "🔍 Redis test output: $redis_test_output"
+            sleep 5
+            attempt=$((attempt + 1))
+        fi
+    done
+    
+    if [ $attempt -gt $max_attempts ]; then
+        echo "❌ Redis failed to become ready after $max_attempts attempts"
+        echo "⚠️  Continuing anyway - Frappe will test Redis connection during startup"
     fi
-done
-
-if [ $attempt -gt $max_attempts ]; then
-    echo "❌ Redis failed to become ready after $max_attempts attempts"
-    exit 1
 fi
 
 # Change to bench directory


### PR DESCRIPTION
Issues addressed:
1. redis-cli may not be available in Frappe base image
2. Need better error output for Redis connection failures
3. Should not exit if Redis test fails - let Frappe handle it

Changes:
- Install redis-tools in both dev and prod Dockerfiles
- Add detailed Redis connection error output
- Skip Redis test if redis-cli not available
- Continue startup even if Redis test fails (Frappe will test it)
- Remove duplicate Redis failure check logic

This should help debug the Redis connection issue and prevent startup failures due to Redis connectivity tests.