### PR TITLE
Fix site_config.json creation order

### DIFF
--- a/backend/start-dev.sh
+++ b/backend/start-dev.sh
@@ -113,10 +113,6 @@ fi
 # Change to bench directory
 cd /home/frappe/frappe-bench
 
-# Create site configuration from template
-echo "📝 Creating site configuration..."
-envsubst < /home/frappe/site_config.json.template > sites/${SITE_NAME}/site_config.json
-
 # Check if site exists, create if it doesn't
 if [ ! -d "sites/${SITE_NAME}" ]; then
     echo "🏗️  Creating new site: ${SITE_NAME}"
@@ -134,6 +130,10 @@ if [ ! -d "sites/${SITE_NAME}" ]; then
 else
     echo "✅ Site ${SITE_NAME} already exists"
 fi
+
+# Create site configuration from template
+echo "📝 Creating site configuration..."
+envsubst < /home/frappe/site_config.json.template > sites/${SITE_NAME}/site_config.json
 
 # Install ERPNext app if not already installed
 if ! bench --site ${SITE_NAME} list-apps | grep -q "erpnext"; then

--- a/backend/start-prod.sh
+++ b/backend/start-prod.sh
@@ -114,10 +114,6 @@ fi
 # Change to bench directory
 cd /home/frappe/frappe-bench
 
-# Create site configuration from template
-echo "📝 Creating site configuration..."
-envsubst < /home/frappe/site_config.json.template > sites/${SITE_NAME}/site_config.json
-
 # Check if site exists, create if it doesn't
 if [ ! -d "sites/${SITE_NAME}" ]; then
     echo "🏗️  Creating new site: ${SITE_NAME}"
@@ -135,6 +131,10 @@ if [ ! -d "sites/${SITE_NAME}" ]; then
 else
     echo "✅ Site ${SITE_NAME} already exists"
 fi
+
+# Create site configuration from template
+echo "📝 Creating site configuration..."
+envsubst < /home/frappe/site_config.json.template > sites/${SITE_NAME}/site_config.json
 
 # Install ERPNext app if not already installed
 if ! bench --site ${SITE_NAME} list-apps | grep -q "erpnext"; then


### PR DESCRIPTION
The script was trying to create the site configuration file before the site directory existed, causing 'No such file or directory' error.

Changes:
- Move site creation before site configuration file creation
- Ensure sites/{SITE_NAME} directory exists before writing config file
- Apply fix to both development and production startup scripts

This resolves the '/home/frappe/start-dev.sh: line 118: sites/pim-experiment/site_config.json: No such file or directory' error.