### PR TITLE
Fix MariaDB SQL mode compatibility for Railway deployment

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -36,13 +36,14 @@ USER frappe
 # Set working directory
 WORKDIR /home/frappe/frappe-bench
 
-# Copy startup script
+# Copy startup script and configuration files
 COPY --chown=frappe:frappe start-dev.sh /home/frappe/start-dev.sh
 COPY --chown=frappe:frappe site_config.json.template /home/frappe/site_config.json.template
+COPY --chown=frappe:frappe init_db.py /home/frappe/init_db.py
 
 # Make startup script executable
 USER root
-RUN chmod +x /home/frappe/start-dev.sh
+RUN chmod +x /home/frappe/start-dev.sh /home/frappe/init_db.py
 USER frappe
 
 # Expose ports for web server and socketio

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -26,10 +26,11 @@ WORKDIR /home/frappe/frappe-bench
 # Copy startup script and configuration template
 COPY --chown=frappe:frappe start-prod.sh /home/frappe/start-prod.sh
 COPY --chown=frappe:frappe site_config.json.template /home/frappe/site_config.json.template
+COPY --chown=frappe:frappe init_db.py /home/frappe/init_db.py
 
 # Make startup script executable
 USER root
-RUN chmod +x /home/frappe/start-prod.sh
+RUN chmod +x /home/frappe/start-prod.sh /home/frappe/init_db.py
 USER frappe
 
 # Expose port for web server

--- a/backend/init_db.py
+++ b/backend/init_db.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""
+Database initialization script to set SQL mode for Railway MariaDB compatibility.
+This script sets the SQL mode to be more permissive for TEXT/BLOB default values.
+"""
+
+import os
+import sys
+import MySQLdb
+from urllib.parse import urlparse
+
+def init_database():
+    """Initialize database with proper SQL mode settings."""
+    
+    # Parse DATABASE_URL
+    database_url = os.environ.get('DATABASE_URL')
+    if not database_url:
+        print("❌ DATABASE_URL not found")
+        return False
+    
+    try:
+        parsed = urlparse(database_url)
+        
+        # Connect to database
+        print("🔧 Connecting to database to set SQL mode...")
+        conn = MySQLdb.connect(
+            host=parsed.hostname,
+            port=parsed.port or 3306,
+            user=parsed.username,
+            passwd=parsed.password,
+            db=parsed.path.lstrip('/'),
+            charset='utf8mb4'
+        )
+        
+        cursor = conn.cursor()
+        
+        # Set SQL mode to be more permissive
+        # Remove STRICT_TRANS_TABLES and NO_ZERO_DATE to allow default values for TEXT columns
+        sql_mode_query = """
+        SET SESSION sql_mode = 'ONLY_FULL_GROUP_BY,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'
+        """
+        
+        cursor.execute(sql_mode_query)
+        
+        # Also set it globally if we have permissions
+        try:
+            global_sql_mode_query = """
+            SET GLOBAL sql_mode = 'ONLY_FULL_GROUP_BY,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'
+            """
+            cursor.execute(global_sql_mode_query)
+            print("✅ Set global SQL mode successfully")
+        except MySQLdb.Error as e:
+            print(f"⚠️  Could not set global SQL mode (this is normal for Railway): {e}")
+        
+        # Verify current SQL mode
+        cursor.execute("SELECT @@sql_mode")
+        current_mode = cursor.fetchone()[0]
+        print(f"✅ Current SQL mode: {current_mode}")
+        
+        cursor.close()
+        conn.close()
+        
+        print("✅ Database SQL mode configured successfully")
+        return True
+        
+    except Exception as e:
+        print(f"❌ Failed to configure database SQL mode: {e}")
+        return False
+
+if __name__ == "__main__":
+    success = init_database()
+    sys.exit(0 if success else 1)

--- a/backend/site_config.json.template
+++ b/backend/site_config.json.template
@@ -5,6 +5,12 @@
   "db_user": "${DB_USER}",
   "db_password": "${DB_PASSWORD}",
   "db_type": "mariadb",
+  "db_socket": "",
+  "db_ssl_ca": "",
+  "db_ssl_cert": "",
+  "db_ssl_key": "",
+  "db_charset": "utf8mb4",
+  "db_collation": "utf8mb4_unicode_ci",
   
   "redis_cache": "redis://:${REDIS_PASSWORD}@${REDIS_HOST}:${REDIS_PORT}/0",
   "redis_queue": "redis://:${REDIS_PASSWORD}@${REDIS_HOST}:${REDIS_PORT}/1",

--- a/backend/start-dev.sh
+++ b/backend/start-dev.sh
@@ -113,6 +113,10 @@ fi
 # Change to bench directory
 cd /home/frappe/frappe-bench
 
+# Initialize database SQL mode for MariaDB compatibility
+echo "🔧 Initializing database SQL mode..."
+python3 /home/frappe/init_db.py
+
 # Check if site exists, create if it doesn't
 if [ ! -d "sites/${SITE_NAME}" ]; then
     echo "🏗️  Creating new site: ${SITE_NAME}"

--- a/backend/start-prod.sh
+++ b/backend/start-prod.sh
@@ -114,6 +114,10 @@ fi
 # Change to bench directory
 cd /home/frappe/frappe-bench
 
+# Initialize database SQL mode for MariaDB compatibility
+echo "🔧 Initializing database SQL mode..."
+python3 /home/frappe/init_db.py
+
 # Check if site exists, create if it doesn't
 if [ ! -d "sites/${SITE_NAME}" ]; then
     echo "🏗️  Creating new site: ${SITE_NAME}"


### PR DESCRIPTION
Issue: MySQLdb.OperationalError (1101) - BLOB, TEXT, GEOMETRY or JSON column 'content' can't have a default value

This error occurs because Railway's MariaDB has strict SQL mode enabled, which doesn't allow default values for TEXT/BLOB columns.

Changes:
1. Created init_db.py script to set permissive SQL mode before site creation
2. Added database configuration parameters to site_config.json.template
3. Updated both Dockerfiles to include the init_db.py script
4. Added database initialization step to both startup scripts

The script sets SQL mode to remove STRICT_TRANS_TABLES and other restrictive settings that prevent Frappe's DocType migrations from working properly.

This should resolve the Workspace DocType migration error and allow the site creation to proceed.