### PR TITLE
Fix mysql-client package name for modern Ubuntu/Debian

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y \
     iputils-ping \
     procps \
     redis-tools \
-    mysql-client \
+    default-mysql-client \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Python development tools

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
     curl \
     wget \
     redis-tools \
-    mysql-client \
+    default-mysql-client \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 


### PR DESCRIPTION
Issue: Package 'mysql-client' has no installation candidate

The mysql-client package name has changed in newer Ubuntu/Debian versions. Updated both Dockerfiles to use 'default-mysql-client' which is the correct package name that provides the mysql command-line client.

This should resolve the Docker build error and allow the mysql CLI to be available for the database initialization script.